### PR TITLE
Fixed two any type annotations

### DIFF
--- a/pouchDB/pouch.d.ts
+++ b/pouchDB/pouch.d.ts
@@ -178,7 +178,7 @@ interface PouchRevsDiffOptions {
 
 interface PouchReplicateOptions {
 	continuous?: boolean;
-	onChange?: (any) => void;
+	onChange?: (e: any) => void;
 	filter?: any;			// Can be either string or PouchFilter
 	complete?: (err: PouchError, res: PouchChanges) => void;
 }
@@ -229,4 +229,4 @@ declare module 'pouchdb' {
 // emit is the function that the PouchFilter.map function should call in order to add a particular item to
 // a filter view.
 //
-declare function emit(key: any, value: any);
+declare function emit(key: any, value: any): void;


### PR DESCRIPTION
Fixed two TypeScript errors when noImplicitAny is set to true:

    .../typings/globals/pouchdb/pouch/index.d.ts(178,14): error TS7006: Parameter 'any' implicitly has an 'any' type.
    .../typings/globals/pouchdb/pouch/index.d.ts(229,18): error TS7010: 'emit', which lacks return-type annotation, implicitly has an 'any' return type.